### PR TITLE
Support JSON output + small typo fix

### DIFF
--- a/cmd/piv.go
+++ b/cmd/piv.go
@@ -55,6 +55,12 @@ func init() {
 		"Comma-separated list of allowed touch policies. If not set all policies are accepted. (never,always,cached)",
 	)
 
+	pivCmd.Flags().Bool(
+		"json",
+		false,
+		"Use JSON output format",
+	)
+
 	pivCmd.Flags().String(
 		"ssh-pub-key",
 		"",
@@ -144,16 +150,23 @@ func pivVerify(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	res := &result{Cmd: cmd}
+	res.Data.Error = &resultError{}
+
+	if val, err := cmd.Flags().GetBool("json"); err == nil {
+		res.JSON = val
+	}
+
 	errors := false
 
 	attestation, err := piv.VerifyAttestation(verifyReq)
-	if attestation != nil {
+	if attestation != nil && !res.JSON {
 		printPIVAttestation(cmd.OutOrStdout(), attestation)
 	}
 
-	cmd.Println("\nAttestation Policy Checks:")
+	res.Printf("\nAttestation Policy Checks:\n")
 	if err == nil {
-		cmd.Println("✔ All policy checks OK")
+		res.Printf("✔ All policy checks OK\n")
 	} else {
 		errors = true
 		verifyErrs, ok := err.(piv.VerificationErrors)
@@ -161,16 +174,16 @@ func pivVerify(cmd *cobra.Command, args []string) error {
 			return err
 		}
 		for _, e := range verifyErrs {
-			cmd.Println("✖", e)
+			res.PrintE(e.Error())
 		}
 	}
 
 	// if --ssh-pub-key=file was specified, compare it to the public key in the attestation
 	if sshPubKey != nil {
-		cmd.Printf("\nSSH public key file '%s':\n", sshPubKeyFile)
+		res.Printf("\nSSH public key file '%s':\n", sshPubKeyFile)
 
 		if pubkeys.Compare(sshPubKey, attestCert.PublicKey) {
-			cmd.Println("✔ SSH public key file matches attestation public key")
+			res.Printf("✔ SSH public key file matches attestation public key\n")
 		} else {
 			errors = true
 			sshFP := ssh.FingerprintSHA256(sshPubKey)
@@ -178,10 +191,16 @@ func pivVerify(cmd *cobra.Command, args []string) error {
 			certFP := ssh.FingerprintSHA256(certSSHpub)
 
 			if err != nil {
-				cmd.Printf("✖ Unable to parse attestation cert public key: %v\n", err)
+				res.PrintE(fmt.Sprintf("Unable to parse attestation cert public key: %v", err))
 			} else {
-				cmd.Printf("✖ SSH public key (%s) does not match attestation public key (%s)\n", sshFP, certFP)
+				res.PrintE(fmt.Sprintf("SSH public key (%s) does not match attestation public key (%s)", sshFP, certFP))
 			}
+		}
+	}
+
+	if res.JSON {
+		if err = res.PrintResultJSON(attestation); err != nil {
+			return err
 		}
 	}
 

--- a/pkg/pgp/attestation.go
+++ b/pkg/pgp/attestation.go
@@ -6,6 +6,7 @@ import (
 	"encoding/asn1"
 	"encoding/binary"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"time"
 )
@@ -45,6 +46,11 @@ var keysourceNames = []string{
 
 func (k Keysource) String() string {
 	return keysourceNames[k]
+}
+
+// MarshalJSON encodes value into String().
+func (k Keysource) MarshalJSON() ([]byte, error) {
+	return json.Marshal(k.String())
 }
 
 // Slot represents the YubiKey card slot that is covered by the attestation.
@@ -90,6 +96,11 @@ func (f Formfactor) String() string {
 	return formfactorNames[f]
 }
 
+// MarshalJSON encodes value into String().
+func (f Formfactor) MarshalJSON() ([]byte, error) {
+	return json.Marshal(f.String())
+}
+
 // TouchPolicy represents proof-of-presence requirements when signing or
 // decrypting with asymmetric key in a given slot.
 type TouchPolicy int
@@ -114,6 +125,11 @@ var touchPolicyNames = []string{
 
 func (t TouchPolicy) String() string {
 	return touchPolicyNames[t]
+}
+
+// MarshalJSON encodes value into String().
+func (t TouchPolicy) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.String())
 }
 
 // Attestation contains additional information about a key attested to be on a

--- a/pkg/pgp/verify.go
+++ b/pkg/pgp/verify.go
@@ -83,7 +83,7 @@ func (v *verifier) verify(req VerificationRequest) (*Attestation, error) {
 	// Verify signatures:
 	// The Attestation Signer Cert from the yubikey must be signed by YubiCo's attestation root
 	if err := verifySignature(root, req.AttestSignerCert); err != nil {
-		errs = append(errs, fmt.Errorf("attestation signer certifcate is not signed by the YubiCo OpenPGP Root CA: %v", err))
+		errs = append(errs, fmt.Errorf("attestation signer certificate is not signed by the YubiCo OpenPGP Root CA: %v", err))
 	}
 	// The Attestation Cert must be signed by the Attestation Signer Cert
 	if err := verifySignature(req.AttestSignerCert, req.AttestCert); err != nil {

--- a/pkg/pgp/verify_test.go
+++ b/pkg/pgp/verify_test.go
@@ -46,7 +46,7 @@ func TestVerify_NotSignedByYubiCoRoot(t *testing.T) {
 	assert.NotNil(t, err)
 
 	verifyErrs := err.(VerificationErrors)
-	assert.Contains(t, verifyErrs, errors.New("attestation signer certifcate is not signed by the YubiCo OpenPGP Root CA: crypto/rsa: verification error"))
+	assert.Contains(t, verifyErrs, errors.New("attestation signer certificate is not signed by the YubiCo OpenPGP Root CA: crypto/rsa: verification error"))
 }
 
 func TestVerify_NotSignedByOnDeviceAttestationKey(t *testing.T) {

--- a/pkg/piv/attestation.go
+++ b/pkg/piv/attestation.go
@@ -26,6 +26,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
+	"encoding/json"
 	"fmt"
 )
 
@@ -87,6 +88,11 @@ func (f Formfactor) String() string {
 	return formfactorNames[f]
 }
 
+// MarshalJSON encodes value into String().
+func (f Formfactor) MarshalJSON() ([]byte, error) {
+	return json.Marshal(f.String())
+}
+
 // PINPolicy represents PIN requirements when signing or decrypting with an
 // asymmetric key in a given slot.
 type PINPolicy int
@@ -112,6 +118,11 @@ func (p PINPolicy) String() string {
 	return pinpolicyNames[p]
 }
 
+// MarshalJSON encodes value into String().
+func (p PINPolicy) MarshalJSON() ([]byte, error) {
+	return json.Marshal(p.String())
+}
+
 // TouchPolicy represents proof-of-presence requirements when signing or
 // decrypting with asymmetric key in a given slot.
 type TouchPolicy int
@@ -131,6 +142,11 @@ var touchPolicyNames = []string{
 
 func (t TouchPolicy) String() string {
 	return touchPolicyNames[t]
+}
+
+// MarshalJSON encodes value into String().
+func (t TouchPolicy) MarshalJSON() ([]byte, error) {
+	return json.Marshal(t.String())
 }
 
 // Attestation returns additional information about a key attested to be on a

--- a/pkg/piv/verify.go
+++ b/pkg/piv/verify.go
@@ -102,7 +102,7 @@ func (v *verifier) verify(req VerificationRequest) (*Attestation, error) {
 	// Verify signatures:
 	// The Attestation Signer Cert from the yubikey must be signed by YubiCo's attestation root
 	if err := verifySignature(root, req.AttestSignerCert); err != nil {
-		errs = append(errs, fmt.Errorf("attestation signer certifcate is not signed by YubiCo PIV Root CA: %v", err))
+		errs = append(errs, fmt.Errorf("attestation signer certificate is not signed by YubiCo PIV Root CA: %v", err))
 	}
 	// The Attestation Cert must be signed by the Attestation Signer Cert
 	if err := verifySignature(req.AttestSignerCert, req.AttestCert); err != nil {

--- a/pkg/piv/verify_test.go
+++ b/pkg/piv/verify_test.go
@@ -46,7 +46,7 @@ func TestVerify_NotSignedByYubiCoRoot(t *testing.T) {
 	assert.NotNil(t, err)
 
 	verifyErrs := err.(VerificationErrors)
-	assert.Contains(t, verifyErrs, errors.New("attestation signer certifcate is not signed by YubiCo PIV Root CA: crypto/rsa: verification error"))
+	assert.Contains(t, verifyErrs, errors.New("attestation signer certificate is not signed by YubiCo PIV Root CA: crypto/rsa: verification error"))
 }
 
 func TestVerify_NotSignedByOnDeviceAttestationKey(t *testing.T) {


### PR DESCRIPTION
This adds a --json argument to the piv and pgp commands. Examples below.

```
$ yk-attest-verify pgp --json ~/nano.aut.pem ~/nano.att.pem --allowed-slots AUT --allowed-cardholders 'Phi Test'
{
  "Attestation": {
    "Cardholder": "Phi Test",
    "Keysource": "Generated",
    "Slot": "AUT",
    "Version": {
      "Major": 5,
      "Minor": 2,
      "Patch": 7
    },
    "Fingerprint": "d1bcb10f24add1c719fa4ae780366e8f655aae64",
    "GenerationDate": "2023-02-21T14:11:33+01:00",
    "SignatureCounter": 0,
    "Serial": 12396340,
    "Formfactor": "USB-A Nano",
    "TouchPolicy": "Enabled-Permanent-Cached"
  },
  "Error": []
}
```
```
$ yk-attest-verify pgp --json ~/nano.aut.pem ~/nano.att.pem --allowed-slots AUT --allowed-cardholders 'Phi Fail' --allowed-touch-policies 'Enabled'
{
  "Attestation": {
    "Cardholder": "Phi Test",
    "Keysource": "Generated",
    "Slot": "AUT",
    "Version": {
      "Major": 5,
      "Minor": 2,
      "Patch": 7
    },
    "Fingerprint": "d1bcb10f24add1c719fa4ae780366e8f655aae64",
    "GenerationDate": "2023-02-21T14:11:33+01:00",
    "SignatureCounter": 0,
    "Serial": 12396340,
    "Formfactor": "USB-A Nano",
    "TouchPolicy": "Enabled-Permanent-Cached"
  },
  "Error": [
    "Touch Policy 'Enabled-Permanent-Cached' is not allowed",
    "Unexpected cardholder 'Phi Test'"
  ]
}
```