### PR TITLE
[minor] Write JSON output to stdout

### DIFF
--- a/cmd/helpers.go
+++ b/cmd/helpers.go
@@ -4,6 +4,7 @@ import (
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
+	"fmt"
 	"os"
 	"strings"
 
@@ -77,6 +78,6 @@ func (o *result) PrintResultJSON(attestation interface{}) error {
 	if err != nil {
 		return err
 	}
-	o.Cmd.Printf("%s\n", data)
+	fmt.Fprintf(o.Cmd.OutOrStdout(), "%s\n", data)
 	return nil
 }


### PR DESCRIPTION
When json is specifically requested, it should go to stdout, not stderr. My mistake, it should have been like this in 9db9d0ed0 already.