### PR TITLE
Add support for "DEC" as an alias for "ENC"

### DIFF
--- a/cmd/pgp.go
+++ b/cmd/pgp.go
@@ -118,6 +118,8 @@ func pgpVerify(cmd *cobra.Command, args []string) error {
 			switch i {
 			case "AUT", "SIG", "ENC":
 				verifyReq.Policy.AllowedSlots = append(verifyReq.Policy.AllowedSlots, pgp.Slot(i))
+			case "DEC":
+				verifyReq.Policy.AllowedSlots = append(verifyReq.Policy.AllowedSlots, pgp.Slot("ENC"))
 			default:
 				return fmt.Errorf("--allowed-slots unknown slot name '%v'", i)
 			}

--- a/pkg/pgp/attestation.go
+++ b/pkg/pgp/attestation.go
@@ -313,7 +313,7 @@ func parseSlot(subject string) (Slot, error) {
 	switch slot {
 	case "SIG":
 		return SlotSignature, nil
-	case "ENC":
+	case "ENC", "DEC":
 		return SlotEncrypt, nil
 	case "AUT":
 		return SlotAuthenticate, nil


### PR DESCRIPTION
Some YubiKeys use DEC for the encryption keys, which previously would result in an error saying DEC was an unknown type. This commit adds support for DEC keys by aliasing them to ENC